### PR TITLE
Added support for Google Analytics User-ID tracking

### DIFF
--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -102,6 +102,21 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
         setTrackingPrefix(trackingPrefix);
     }
 
+	    /**
+	  * Instantiate new Google Analytics tracker by id and domain.
+	  *
+	  * @param trackerId The tracking id from Google Analytics. Something like
+	  * 'UA-658457-8'.
+	  * @param domainName The name of the domain to be tracked. Something like
+	  * 'vaadin.com'. Universal tracker is created by default.
+	  * @param userId a unique, persistent, and non-personally identifiable string ID.
+	  */
+	 public GoogleAnalyticsTracker(String trackerId, String domainName, String trackingPrefix, String userId) {
+	     this(trackerId);
+	     setDomainName(domainName);
+	     setTrackingPrefix(trackingPrefix);
+	     setUserId(userId);
+	 }
 
     /**
      * Get the domain name associated with this tracker.
@@ -199,6 +214,36 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
     public void setTrackerId(String trackerId) {
         getState().trackerId = trackerId;
     }
+    
+	/**
+	 * Sets the UserId to send to Google Analytics. The User-ID feature must be
+	 * enabled within the Google Analytics admin for User-ID tracking to work.
+	 * See the Google Analytics documentation for more information. User-ID
+	 * tracking is only available if using the universal tracker.
+	 *
+	 * @param userId
+	 *            a unique, persistent, and non-personally identifiable string
+	 *            ID.
+	 * @throws UnsupportedOperationException
+	 *             when attempting to call this method and not using universal
+	 *             tracking mode.
+	 */
+	public void setUserId(String userId) throws UnsupportedOperationException {
+		if (!getState().universalTracking)
+			throw new UnsupportedOperationException(
+					"User-ID tracking only supported when using universal tracking mode.");
+		getState().userId = userId;
+	}
+    
+    /**
+     * Gets the User-ID that was previously set.
+     * 
+     * @return
+     */
+    public String getUserId() {
+    	return getState().userId;
+    }
+    
 
     /**
      * Track a single page view. This effectively invokes the 'trackPageview' in

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTrackerState.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTrackerState.java
@@ -9,5 +9,6 @@ public class GoogleAnalyticsTrackerState extends JavaScriptExtensionState {
     public String trackerId;
     public boolean allowAnchor = true;
     public String domainName  = "none";
+    public String userId = null;
 
 }

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
@@ -57,8 +57,9 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
         var trackerId = state.trackerId;
         var domainName = state.domainName;
         var allowAnchor = state.allowAnchor;
+        var userId = state.userId;
 
-        window._gaut('create', trackerId, {'cookieDomain': domainName, 'allowAnchor': allowAnchor});
+        window._gaut('create', trackerId, {'cookieDomain': domainName, 'allowAnchor': allowAnchor, 'userId': userId});
     };
 
 
@@ -69,7 +70,7 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
             self.legacyTrack(pageId);
         }
     };
-
+    
     this.legacyTrack = function(pageId) {
 
         if (pageId) {

--- a/demo/src/main/java/org/vaadin/googleanalytics/tracking/demo/GoogleAnalyticsTrackerDemo.java
+++ b/demo/src/main/java/org/vaadin/googleanalytics/tracking/demo/GoogleAnalyticsTrackerDemo.java
@@ -31,6 +31,9 @@ public class GoogleAnalyticsTrackerDemo extends UI {
         // Example: Create a tracker for vaadin.com domain.
         // GoogleAnalyticsTracker tracker = new GoogleAnalyticsTracker(
         // "UA-658457-8", "vaadin.com");
+        
+        tracker.setUserId("12345"); //optional: set the User-ID. Must also enable User-ID tracking within Google Analytics admin.
+        
         // attach the GA tracker to this UI
         tracker.extend(this);
 


### PR DESCRIPTION
I had a need for User-ID tracking with Google Analytics / Vaadin, so I updated the vaadin-ga-tracker. Please feel free to use / incorporate as you see fit.