### PR TITLE
Add dimension support via sending of page view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-Forked to add dimension support.
+# Google analytics tracking integration for Vaadin 8
 
-Used in NeoLoad Web
+
+
+## Download release
+
+Official releases of this add-on are available at Vaadin Directory. For Maven instructions, download and reviews, go to http://vaadin.com/addon/vaadin-ga-tracker
+
+## Building and running demo
+
+    git clone https://github.com/samie/vaadin-ga-tracker.git
+    cd vaadin-ga-tracker
+    mvn clean install
+    cd demo
+    mvn jetty:run
+
+To see the demo, navigate to http://localhost:8080/

--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
-# Google analytics tracking integration for Vaadin 8
+Forked to add dimension support.
 
-
-
-## Download release
-
-Official releases of this add-on are available at Vaadin Directory. For Maven instructions, download and reviews, go to http://vaadin.com/addon/vaadin-ga-tracker
-
-## Building and running demo
-
-    git clone https://github.com/samie/vaadin-ga-tracker.git
-    cd vaadin-ga-tracker
-    mvn clean install
-    cd demo
-    mvn jetty:run
-
-To see the demo, navigate to http://localhost:8080/
+Used in NeoLoad Web

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -248,14 +248,54 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
     
 
     /**
-     * Track a single page view. This effectively invokes the 'trackPageview' in
-     * ga.js file.
+     * Tracks a single page view. This effectively invokes the 'trackPageview' in ga.js file.
      *
-     * @param pageId The page id. Use a scheme like '/topic/page' or
-     * '/view/action'.
+     * @param pageId The page id. Use a scheme like '/topic/page' or '/view/action'.
      */
     public void trackPageview(String pageId) {
-        callFunction("trackPageView", trackingPrefix != null && trackingPrefix.length() > 0 ? trackingPrefix + pageId : pageId);
+        callFunction("trackPageView", getPageId(pageId));
+    }
+
+    /**
+     * Tracks a single page view adding a dimension value (for the given dimension index).
+     * This effectively invokes the 'trackPageViewWithDimension' in ga.js file.
+     * <p>
+     * <b>Does not support legacy Google Analytics API</b> (i.e. in case {@code isUniversalTracking} is {@code false}).
+     *
+     * @param pageId The page id. Use a scheme like '/topic/page' or '/view/action'.
+     * @param dimensionKeyIndex the dimension index of the configured dimension
+     * @param dimensionValue the dimension value
+     *
+     * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets">GA dimensions</a>
+     *
+     * @throws UnsupportedOperationException if legacy Google Analytics API is used
+     * @throws IllegalArgumentException if {@code pageId} or {@code dimensionValue} is {@code null} or empty
+     * @throws IllegalArgumentException if {@code pageId} or {@code dimensionValue} is {@code null} or empty
+     */
+    public void trackPageViewWithDimension(final String pageId, final int dimensionKeyIndex, final String dimensionValue) {
+        checkTrackPageViewWithDimensionArguments(pageId, dimensionKeyIndex, dimensionValue);
+
+        if(!isUniversalTracking()) {
+            throw new UnsupportedOperationException("No legacy API support for this method");
+        }
+
+        callFunction("trackPageViewWithDimension", getPageId(pageId), dimensionKeyIndex, dimensionValue);
+    }
+
+    private static void checkTrackPageViewWithDimensionArguments(final String pageId, final int dimensionKeyIndex, final String dimensionValue) {
+        if(pageId == null || pageId.isEmpty()) {
+            throw new IllegalArgumentException("Page id is required");
+        }
+        if(dimensionKeyIndex < 0) {
+            throw new IllegalArgumentException("Dimension key index must be >= 0");
+        }
+        if(dimensionValue == null || dimensionValue.isEmpty()) {
+            throw new IllegalArgumentException("Dimension value is required");
+        }
+    }
+
+    private String getPageId(final String pageId) {
+        return trackingPrefix != null && trackingPrefix.length() > 0 ? trackingPrefix + pageId : pageId;
     }
 
     /**

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -4,6 +4,13 @@ import com.vaadin.annotations.JavaScript;
 import com.vaadin.navigator.ViewChangeListener;
 import com.vaadin.server.AbstractJavaScriptExtension;
 import com.vaadin.ui.UI;
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Component for triggering Google Analytics page views. Usage:
@@ -263,8 +270,7 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
      * <b>Does not support legacy Google Analytics API</b> (i.e. in case {@code isUniversalTracking} is {@code false}).
      *
      * @param pageId The page id. Use a scheme like '/topic/page' or '/view/action'.
-     * @param dimensionKeyIndex the dimension index of the configured dimension
-     * @param dimensionValue the dimension value
+     * @param dimensions the {@link Dimension}s
      *
      * @see <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets">GA dimensions</a>
      *
@@ -272,26 +278,53 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
      * @throws IllegalArgumentException if {@code pageId} or {@code dimensionValue} is {@code null} or empty
      * @throws IllegalArgumentException if {@code pageId} or {@code dimensionValue} is {@code null} or empty
      */
-    public void trackPageViewWithDimension(final String pageId, final int dimensionKeyIndex, final String dimensionValue) {
-        checkTrackPageViewWithDimensionArguments(pageId, dimensionKeyIndex, dimensionValue);
+    public void trackPageViewWithDimensions(final String pageId, final List<Dimension> dimensions) {
+        checkTrackPageViewWithDimensionArguments(pageId, dimensions);
 
         if(!isUniversalTracking()) {
             throw new UnsupportedOperationException("No legacy API support for this method");
         }
-
-        callFunction("trackPageViewWithDimension", getPageId(pageId), dimensionKeyIndex, dimensionValue);
+        callFunction("trackPageViewWithDimensions", getPageId(pageId), toJson(dimensions));
     }
 
-    private static void checkTrackPageViewWithDimensionArguments(final String pageId, final int dimensionKeyIndex, final String dimensionValue) {
+    private JsonValue toJson(final List<Dimension> dimensions) {
+
+        final JsonArray array = Json.instance().createArray();
+
+        final LongAdder index = new LongAdder();
+        dimensions.forEach(d -> {
+            final JsonObject jsonDimension = Json.instance().createObject();
+            jsonDimension.put("dimensionKeyIndex", d.dimensionKeyIndex);
+            jsonDimension.put("dimensionValue", d.dimensionValue);
+            array.set(index.intValue(), jsonDimension);
+            index.increment();
+        });
+
+        return array;
+    }
+
+    public static class Dimension {
+        private final int dimensionKeyIndex;
+        private final String dimensionValue;
+
+        public Dimension(final int dimensionKeyIndex, final String dimensionValue) {
+            this.dimensionKeyIndex = dimensionKeyIndex;
+            this.dimensionValue = dimensionValue;
+        }
+    }
+
+    private static void checkTrackPageViewWithDimensionArguments(final String pageId, final List<Dimension> dimensions) {
         if(pageId == null || pageId.isEmpty()) {
             throw new IllegalArgumentException("Page id is required");
         }
-        if(dimensionKeyIndex < 0) {
-            throw new IllegalArgumentException("Dimension key index must be >= 0");
-        }
-        if(dimensionValue == null || dimensionValue.isEmpty()) {
-            throw new IllegalArgumentException("Dimension value is required");
-        }
+        dimensions.forEach(d -> {
+            if(d.dimensionKeyIndex < 0) {
+                throw new IllegalArgumentException("Dimension key index must be >= 0");
+            }
+            if(d.dimensionValue == null || d.dimensionValue.isEmpty()) {
+                throw new IllegalArgumentException("Dimension value is required");
+            }
+        });
     }
 
     private String getPageId(final String pageId) {

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
@@ -70,6 +70,10 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
             self.legacyTrack(pageId);
         }
     };
+
+    this.trackPageViewWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
+        // TODO
+    }
     
     this.trackEvent = function (eventCategory, eventAction, eventLabel, eventValue) {
         window._gaut('send', {
@@ -97,6 +101,16 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
         } else {
             window._gaut('send', 'pageview');
         }
+    };
+
+    this.universalTrackWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
+
+        var args = {
+            'page': pageId
+        };
+        args['dimension' + dimensionKeyIndex] = dimensionValue;
+
+        window._gaut('send', 'pageview', args);
     };
 
     this.onStateChange = function() {

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
@@ -72,8 +72,20 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
     };
 
     this.trackPageViewWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
-        // TODO
+        if (self.getState().universalTracking) {
+            self.universalTrackWithDimension(pageId, dimensionKeyIndex, dimensionValue);
+        }
     }
+
+    this.universalTrackWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
+
+        var args = {
+            'page': pageId
+        };
+        args['dimension' + dimensionKeyIndex] = dimensionValue;
+
+        window._gaut('send', 'pageview', args);
+    };
     
     this.trackEvent = function (eventCategory, eventAction, eventLabel, eventValue) {
         window._gaut('send', {
@@ -101,16 +113,6 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
         } else {
             window._gaut('send', 'pageview');
         }
-    };
-
-    this.universalTrackWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
-
-        var args = {
-            'page': pageId
-        };
-        args['dimension' + dimensionKeyIndex] = dimensionValue;
-
-        window._gaut('send', 'pageview', args);
     };
 
     this.onStateChange = function() {

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
@@ -71,18 +71,23 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
         }
     };
 
-    this.trackPageViewWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
+    this.trackPageViewWithDimensions = function(pageId, dimensions) {
         if (self.getState().universalTracking) {
-            self.universalTrackWithDimension(pageId, dimensionKeyIndex, dimensionValue);
+            self.universalTrackWithDimensions(pageId, dimensions);
         }
     }
 
-    this.universalTrackWithDimension = function(pageId, dimensionKeyIndex, dimensionValue) {
+    this.universalTrackWithDimensions = function(pageId, dimensions) {
 
         var args = {
             'page': pageId
         };
-        args['dimension' + dimensionKeyIndex] = dimensionValue;
+
+        for(i = 0 ; i < dimensions.length ; i ++) {
+            var dimension = dimensions[i];
+            var key = 'dimension' + dimension["dimensionKeyIndex"];
+            args[key] = dimension["dimensionValue"];
+        }
 
         window._gaut('send', 'pageview', args);
     };


### PR DESCRIPTION
See: 

- custom dimensions docs:

https://support.google.com/analytics/answer/2709829?hl=en)

- https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets for tracking code.

What has been integrated is:

ga('send', 'pageview', {
  'dimension15':  'My Custom Dimension value',
  'dimension42':  'My Custom Dimension value 2'
});

(universal tracking suport only)
