### PR TITLE
added Google Analytics IP anonymization feature

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.vaadin.addons</groupId>
         <artifactId>googleanalyticstracker-addon</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>3.1-SNAPSHOT</version>
     </parent>
 
 

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -246,7 +246,28 @@ public class GoogleAnalyticsTracker extends AbstractJavaScriptExtension
     	return getState().userId;
     }
     
-
+    /**
+     * Enables/disables the anonymizeIp feature.
+     * 
+     * https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
+     * 
+     * @param anonymizeIp is IP anonymization enabled (default is 'false')
+     */
+    public void setAnonymizeIp(boolean anonymizeIp) {
+        getState().anonymizeIp = anonymizeIp;
+    }
+    
+    /**
+     * This method returns if IP anonymization is enabled (default is 'false')
+     *
+     * https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
+     *
+     * @return true if IP anonymization is enabled
+     */
+    public boolean isAnonymizeIp() {
+        return getState().anonymizeIp;
+    }
+    
     /**
      * Track a single page view. This effectively invokes the 'trackPageview' in
      * ga.js file.

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTrackerState.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTrackerState.java
@@ -10,5 +10,6 @@ public class GoogleAnalyticsTrackerState extends JavaScriptExtensionState {
     public boolean allowAnchor = true;
     public String domainName  = "none";
     public String userId = null;
+    public boolean anonymizeIp = false;
 
 }

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/tracker_extension.js
@@ -60,6 +60,10 @@ window.org_vaadin_googleanalytics_tracking_GoogleAnalyticsTracker = function() {
         var userId = state.userId;
 
         window._gaut('create', trackerId, {'cookieDomain': domainName, 'allowAnchor': allowAnchor, 'userId': userId});
+        
+        if (state.anonymizeIp) {
+            window._gaut('set', 'anonymizeIp', true);
+        }
     };
 
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.vaadin.addons</groupId>
 		<artifactId>googleanalyticstracker-addon</artifactId>
-		<version>3.0-SNAPSHOT</version>
+		<version>3.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>googleanalyticstracker-addon</artifactId>
 	<packaging>pom</packaging>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.1-SNAPSHOT</version>
 	<name>GoogleAnalyticsTracker Project</name>
 
 	<properties>


### PR DESCRIPTION
Hello Sami,

really great work with the Google Analytics Tracker! Unfortunately, in Germany we have to turn on IP Anonymization for Google Analytics to legally use it: https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
This is currently not supported by your addon. I added this feature as a setter method during tracker initialization - as default it is turned off.

There is already another repository which extends your tracker with this feature: https://github.com/danielleon/elleon-public/tree/master/AnonymizedGoogleAnalyticsTracker
However, this repository is a bit outdated and I think this would be a nice addition to your great addon.

If you have some remarks on my code, feel free to note them and I would be happy to change it.

Kind regards,
Sven