### PR TITLE
Update Jetty version in the demo

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -55,7 +55,7 @@
 			<plugin>
 					<groupId>org.eclipse.jetty</groupId>
 					<artifactId>jetty-maven-plugin</artifactId>
-					<version>9.3.7.v20160115</version>
+					<version>9.4.25.v20191220</version>
 					<configuration>
 							<scanIntervalSeconds>-1</scanIntervalSeconds>
 					</configuration>


### PR DESCRIPTION
A newer version of Jetty is needed to support the Java 9 metadata that
is present in some transitive dependencies of newer versions of Vaadin.