### PR TITLE
Bump the vaadin version and update the javadoc

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>10.0.0</vaadin.version>
+        <vaadin.version>14.8.1</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>14.8.1</vaadin.version>
+        <vaadin.version>10.0.7</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -316,7 +316,7 @@ public class GoogleAnalyticsTracker {
      *            the category name, not <code>null</code>
      * @param action
      *            the action name, not <code>null</code>
-     * @param fieldsObject
+     * @param fieldsObject field object
      */
     public void sendEvent(String category, String action, Map<String, Serializable> fieldsObject) {
         ga("send", fieldsObject, "event", category, action);

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/TrackerConfiguration.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/TrackerConfiguration.java
@@ -130,7 +130,7 @@ public class TrackerConfiguration {
     /**
      * Gets the URL from which to load the Google Analytics script.
      * 
-     * @return
+     * @return scriptUrl
      */
     public String getScriptUrl() {
         return scriptUrl;

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>14.8.1</vaadin.version>
+		<vaadin.version>10.0.7</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>10.0.0</vaadin.version>
+		<vaadin.version>14.8.1</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Currently the addon can't run with maven 3.8 because it requires only https repositories and Vaadin 10 is using http repositories.

This PR should fix the issue: https://github.com/samie/vaadin-ga-tracker/issues/25