### PR TITLE
Upgrade to Vaadin 14

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>googleanalyticstracker</artifactId>
     <packaging>jar</packaging>
     <name>GoogleAnalyticsTracker</name>
-    <version>4.0-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <!-- No parent specified to be able to make standalone component for Directory -->
 
 

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -66,6 +66,17 @@
     </dependencies>
 
     <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>	
+
         <plugins>
 
             <plugin>

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>10.0.19</vaadin.version>
+        <vaadin.version>14.9.5</vaadin.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
+++ b/addon/src/main/java/org/vaadin/googleanalytics/tracking/GoogleAnalyticsTracker.java
@@ -102,11 +102,11 @@ public class GoogleAnalyticsTracker {
         pageViewPrefix = config.getPageViewPrefix();
 
         ui.getPage()
-                .executeJavaScript("window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;");
+                .executeJs("window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;");
 
         Map<String, Serializable> gaDebug = config.getGaDebug();
         if (!gaDebug.isEmpty()) {
-            ui.getPage().executeJavaScript("window.ga_debug = $0;", toJsonObject(gaDebug));
+            ui.getPage().executeJs("window.ga_debug = $0;", toJsonObject(gaDebug));
         }
 
         sendAction(createAction("create", config.getCreateFields(), trackingId, config.getCookieDomain()));
@@ -169,7 +169,7 @@ public class GoogleAnalyticsTracker {
             }
         }
 
-        ui.getPage().executeJavaScript("ga.apply(null, arguments)", action);
+        ui.getPage().executeJs("ga.apply(null, arguments)", action);
     }
 
     private static Serializable[] createAction(String command, Map<String, ? extends Serializable> fieldsObject,

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -60,6 +60,11 @@
 							<scanIntervalSeconds>-1</scanIntervalSeconds>
 					</configuration>
 			</plugin>
+			<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-war-plugin</artifactId>
+					<version>3.3.2</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.vaadin.addons</groupId>
 		<artifactId>googleanalyticstracker-addon</artifactId>
-		<version>4.0-SNAPSHOT</version>
+		<version>5.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<vaadin.version>10.0.19</vaadin.version>
+		<vaadin.version>14.9.5</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.vaadin.addons</groupId>
 	<artifactId>googleanalyticstracker-addon</artifactId>
 	<packaging>pom</packaging>
-    <version>4.0-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 	<name>GoogleAnalyticsTracker Project</name>
 
 	<properties>


### PR DESCRIPTION
Close #29. 

I targeted Vaadin 14 because the same codebase works for Vaadin 14-24 (so far).
I also upgraded some maven plugins that fail with newer JVM.